### PR TITLE
feat: add config options, simplification settings, geometry retrieval by id

### DIFF
--- a/geodini/agents/geocoder_agent.py
+++ b/geodini/agents/geocoder_agent.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import os
 import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
@@ -15,6 +16,7 @@ from shapely.geometry import mapping, shape
 from shapely.ops import transform
 
 from geodini import hookspecs, lib
+from geodini.models import MODEL_LIGHT
 from geodini.agents.utils.postgis_exec import (
     clear_geometries_table,
     create_geometries_table,
@@ -72,9 +74,12 @@ class RerankingResult:
     most_probable: str
 
 
+_GEOMETRY_PRECISION = int(os.getenv("GEOMETRY_DECIMAL_PRECISION", "6"))
+
+
 class RoundedFloat(float):
     def __repr__(self):
-        return f"{self:.2f}"
+        return f"{self:.{_GEOMETRY_PRECISION}f}"
 
 
 def recursively_convert(obj):
@@ -93,8 +98,11 @@ def clip_coordinates_with_rounding(geojson: dict[str, Any]) -> dict[str, Any]:
 
 
 def simplify_geometry(
-    geometry: dict[str, Any], tolerance_m: float = 10000
+    geometry: dict[str, Any],
+    tolerance_m: float | None = None,
 ) -> dict[str, Any]:
+    if tolerance_m is None:
+        tolerance_m = float(os.getenv("GEOMETRY_AGENT_SIMPLIFY_TOLERANCE", "10000"))
     to_meters = Transformer.from_crs("EPSG:4326", "EPSG:3857", always_xy=True).transform
     to_degrees = Transformer.from_crs(
         "EPSG:3857", "EPSG:4326", always_xy=True
@@ -111,8 +119,28 @@ def simplify_geometry(
     return geojson
 
 
+def simplify_geometry_to_size(
+    geometry: dict[str, Any],
+    max_bytes: int,
+    initial_tolerance_m: float = 1000,
+    max_iterations: int = 10,
+) -> dict[str, Any]:
+    """Iteratively simplify geometry until JSON representation fits within max_bytes."""
+    tolerance = initial_tolerance_m
+    result = simplify_geometry(geometry, tolerance_m=tolerance)
+
+    for _ in range(max_iterations):
+        serialized = json.dumps(result)
+        if len(serialized.encode("utf-8")) <= max_bytes:
+            return result
+        tolerance *= 2
+        result = simplify_geometry(geometry, tolerance_m=tolerance)
+
+    return result
+
+
 rephrase_agent = Agent(
-    "openai:gpt-4.1-mini",
+    MODEL_LIGHT,
     output_type=RephrasedQuery,
     system_prompt="""
         Given the search query, rephrase it to be more specific and accurate. We will be using this query to search for places in the overture database. So it helps to make the query be full formal name of the place.
@@ -131,7 +159,7 @@ rephrase_agent = Agent(
 
 
 routing_agent = Agent(
-    "openai:gpt-4.1-mini",
+    MODEL_LIGHT,
     output_type=RoutingResult,
     system_prompt="""
         Given the search query, determine if it is a simple or complex query.
@@ -143,7 +171,7 @@ routing_agent = Agent(
 
 
 complex_geocode_query_agent = Agent(
-    "openai:gpt-4.1-mini",
+    MODEL_LIGHT,
     output_type=ComplexGeocodeResult,
     system_prompt="""
         Given the search query, return ALL relevant places to search for in the query as queries.
@@ -170,8 +198,7 @@ complex_geocode_query_agent = Agent(
 
 
 rerank_agent = Agent(
-    # 4o-mini is smarter than 3.5-turbo. And does better in edge cases.
-    "openai:gpt-4.1-mini",
+    MODEL_LIGHT,
     output_type=RerankingResult,
     system_prompt="""
         Given the search query and results, rank them in order of 
@@ -312,6 +339,7 @@ async def simple_geocode(query: str, simplify_geometry: bool = True) -> dict:
         "query": query,
         "results": [
             {
+                "id": most_probable["id"] if most_probable else None,
                 "geometry": most_probable["geometry"] if most_probable else None,
                 "country": most_probable["country"] if most_probable else None,
                 "name": most_probable["name"] if most_probable else query,

--- a/geodini/agents/utils/geocoder.py
+++ b/geodini/agents/utils/geocoder.py
@@ -107,7 +107,8 @@ def build_postgis_query(simplify_geometry: bool = True) -> str:
     """Build PostgreSQL query for searching overture unified data using trigram similarity"""
 
     # Choose geometry function based on whether to simplify
-    geometry_func = "ST_AsGeoJSON(ST_Simplify(geometry, 0.001))" if simplify_geometry else "ST_AsGeoJSON(geometry)"
+    db_tolerance = float(os.getenv("GEOMETRY_DB_SIMPLIFY_TOLERANCE", "0.001"))
+    geometry_func = f"ST_AsGeoJSON(ST_Simplify(geometry, {db_tolerance}))" if simplify_geometry else "ST_AsGeoJSON(geometry)"
 
     sql_query = f"""
         SELECT 
@@ -160,6 +161,48 @@ def build_postgis_query(simplify_geometry: bool = True) -> str:
     """
 
     return sql_query
+
+
+def get_geometry_by_id(
+    division_id: str, simplify: bool = True
+) -> dict[str, Any] | None:
+    """Retrieve geometry for a specific division by ID."""
+    engine = get_postgis_engine()
+    db_tolerance = float(os.getenv("GEOMETRY_DB_SIMPLIFY_TOLERANCE", "0.001"))
+
+    geometry_func = (
+        f"ST_AsGeoJSON(ST_Simplify(geometry, {db_tolerance}))"
+        if simplify
+        else "ST_AsGeoJSON(geometry)"
+    )
+
+    sql_query = f"""
+        SELECT
+            id,
+            COALESCE(common_en_name, primary_name) as name,
+            subtype, country,
+            {geometry_func} as geometry
+        FROM all_geometries
+        WHERE id = :id
+        LIMIT 1
+    """
+
+    try:
+        with engine.begin() as conn:
+            result = conn.execute(text(sql_query), {"id": division_id})
+            row = result.fetchone()
+            if row:
+                return {
+                    "id": row.id,
+                    "name": row.name,
+                    "subtype": row.subtype,
+                    "country": row.country,
+                    "geometry": json.loads(row.geometry) if row.geometry else None,
+                }
+    except Exception as e:
+        logger.error(f"Error retrieving geometry by ID: {e}")
+
+    return None
 
 
 if __name__ == "__main__":

--- a/geodini/agents/utils/postgis_exec.py
+++ b/geodini/agents/utils/postgis_exec.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 import psycopg2
 from pydantic_ai import Agent
 
+from geodini.models import MODEL_HEAVY
+
 
 @dataclass
 class PostGISResult:
@@ -96,16 +98,17 @@ def search_subtype_within_aoi(subtype: str, aoi: dict) -> list[dict]:
     # aoi is the geojson geometry as dict as returned from run_postgis_query
     # return a list of dictionaries of the form:
     # { "geometry": result_geometry_as_json_dict, "country": country_name }
+    db_tolerance = float(os.getenv("GEOMETRY_DB_SIMPLIFY_TOLERANCE", "0.001"))
     conn = get_postgis_connection()
     try:
         with conn.cursor() as cur:
             # Convert AOI dict to GeoJSON string
             aoi_geojson = json.dumps(aoi)
-            
+
             # SQL query to find places of given subtype within the AOI
-            sql_query = """
+            sql_query = f"""
             SELECT 
-                ST_AsGeoJSON(ST_Simplify(geometry, 0.001)) as geometry,
+                ST_AsGeoJSON(ST_Simplify(geometry, {db_tolerance})) as geometry,
                 country,
                 COALESCE(common_en_name, primary_name) as name
             FROM all_geometries
@@ -141,7 +144,7 @@ def search_subtype_within_aoi(subtype: str, aoi: dict) -> list[dict]:
 
 
 postgis_agent = Agent(
-    "openai:gpt-4.1",
+    MODEL_HEAVY,
     output_type=PostGISResult,
     system_prompt="""
     You are a helpful assistant that can help with PostGIS queries.
@@ -185,7 +188,7 @@ postgis_agent = Agent(
 
 
 postgis_query_judgement_agent = Agent(
-    "openai:gpt-4o",
+    MODEL_HEAVY,
     output_type=PostGISResult,
     system_prompt="""
     You are a helpful assistant that can help with PostGIS queries.

--- a/geodini/agents/utils/postgis_exec.py
+++ b/geodini/agents/utils/postgis_exec.py
@@ -106,13 +106,13 @@ def search_subtype_within_aoi(subtype: str, aoi: dict) -> list[dict]:
             aoi_geojson = json.dumps(aoi)
 
             # SQL query to find places of given subtype within the AOI
-            sql_query = f"""
-            SELECT 
-                ST_AsGeoJSON(ST_Simplify(geometry, {db_tolerance})) as geometry,
+            sql_query = """
+            SELECT
+                ST_AsGeoJSON(ST_Simplify(geometry, %s)) as geometry,
                 country,
                 COALESCE(common_en_name, primary_name) as name
             FROM all_geometries
-            WHERE 
+            WHERE
                 source_type = 'division'
                 AND subtype = %s
                 AND geometry IS NOT NULL
@@ -120,12 +120,12 @@ def search_subtype_within_aoi(subtype: str, aoi: dict) -> list[dict]:
                     geometry,
                     ST_GeomFromGeoJSON(%s)
                 )
-            ORDER BY 
+            ORDER BY
                 ST_Area(geometry) DESC
             LIMIT 100
             """
-            
-            cur.execute(sql_query, (subtype, aoi_geojson))
+
+            cur.execute(sql_query, (db_tolerance, subtype, aoi_geojson))
             results = cur.fetchall()
             
             # Convert results to expected format

--- a/geodini/api/api.py
+++ b/geodini/api/api.py
@@ -7,7 +7,8 @@ import uvicorn
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 
-from geodini.agents.geocoder_agent import search
+from geodini.agents.geocoder_agent import search, simplify_geometry_to_size
+from geodini.agents.utils.geocoder import get_geometry_by_id
 from geodini.agents.utils.postgis_exec import get_postgis_connection
 from geodini.cache import init_cache
 
@@ -50,10 +51,11 @@ async def root():
 @app.get("/search")
 async def search_endpoint(
     query: str = Query(..., description="The search query string"),
+    max_bytes: int = Query(0, description="Max geometry size in bytes (0 = use server default)"),
 ) -> dict[str, Any]:
     """
     Unified search endpoint that handles both simple and complex queries.
-    
+
     Simple queries: "New York City", "London in Canada", "India"
     Complex queries: "India and Sri Lanka", "Within 100km of Mumbai", "France north of Paris"
 
@@ -65,6 +67,15 @@ async def search_endpoint(
         # Get result from unified search
         result = await search(query)
 
+        # Apply byte-threshold simplification if requested
+        effective_max_bytes = max_bytes or int(os.getenv("GEOMETRY_MAX_BYTES", "0"))
+        if effective_max_bytes > 0 and result.get("results"):
+            for r in result["results"]:
+                if r.get("geometry"):
+                    r["geometry"] = simplify_geometry_to_size(
+                        r["geometry"], max_bytes=effective_max_bytes
+                    )
+
         return result
 
     except Exception as e:
@@ -72,6 +83,25 @@ async def search_endpoint(
         raise HTTPException(
             status_code=500, detail=f"Error processing search query: {str(e)}"
         )
+
+
+@app.get("/geometry/{geometry_id}")
+async def get_geometry_endpoint(
+    geometry_id: str,
+    simplify: bool = Query(True, description="Whether to simplify the geometry"),
+    max_bytes: int = Query(0, description="Max geometry size in bytes (0 = no limit)"),
+) -> dict[str, Any]:
+    """Retrieve full geometry by division ID."""
+    result = get_geometry_by_id(geometry_id, simplify=simplify)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Geometry not found")
+
+    if max_bytes > 0 and result.get("geometry"):
+        result["geometry"] = simplify_geometry_to_size(
+            result["geometry"], max_bytes=max_bytes
+        )
+
+    return result
 
 
 @app.get("/health")

--- a/geodini/api/mcp_server.py
+++ b/geodini/api/mcp_server.py
@@ -1,3 +1,5 @@
+import os
+
 from mcp.server.fastmcp import FastMCP
 
 from geodini.agents.geocoder_agent import search, simplify_geometry
@@ -10,7 +12,8 @@ async def geocode(query: str) -> str:
     """Geocode a query and download the geojson geometry"""
     result = await search(query)
     if "result" in result and "geometry" in result["result"]:
-        return simplify_geometry(result["result"]["geometry"], tolerance_m=1000)
+        mcp_tolerance = float(os.getenv("GEOMETRY_MCP_SIMPLIFY_TOLERANCE", "1000"))
+        return simplify_geometry(result["result"]["geometry"], tolerance_m=mcp_tolerance)
     return "No geometry found for query"
 
 

--- a/geodini/models.py
+++ b/geodini/models.py
@@ -1,0 +1,35 @@
+"""Centralized LLM model configuration.
+
+Two tiers control all agent models:
+- MODEL_LIGHT: fast/cheap tasks (rephrase, routing, complex parse, rerank)
+- MODEL_HEAVY: SQL generation and error correction
+
+LLM_API_KEY is a convenience env var that auto-maps to the correct
+provider-specific env var based on the model prefix. For multi-provider
+setups, set provider-specific env vars directly instead.
+
+Supported provider prefixes: openai, anthropic, groq, mistral.
+Bedrock uses AWS creds (AWS_ACCESS_KEY_ID, etc.).
+Ollama uses OLLAMA_BASE_URL (no API key needed).
+"""
+
+import os
+
+MODEL_LIGHT = os.getenv("MODEL_LIGHT", "anthropic:claude-haiku-4-5")
+MODEL_HEAVY = os.getenv("MODEL_HEAVY", "anthropic:claude-sonnet-4-6")
+
+_KEY_MAP = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "mistral": "MISTRAL_API_KEY",
+}
+
+_llm_key = os.getenv("LLM_API_KEY", "")
+if _llm_key:
+    _provider = MODEL_LIGHT.split(":")[0]
+    if _provider in _KEY_MAP:
+        os.environ.setdefault(_KEY_MAP[_provider], _llm_key)
+    _heavy_provider = MODEL_HEAVY.split(":")[0]
+    if _heavy_provider != _provider and _heavy_provider in _KEY_MAP:
+        os.environ.setdefault(_KEY_MAP[_heavy_provider], _llm_key)

--- a/geodini/models.py
+++ b/geodini/models.py
@@ -4,9 +4,10 @@ Two tiers control all agent models:
 - MODEL_LIGHT: fast/cheap tasks (rephrase, routing, complex parse, rerank)
 - MODEL_HEAVY: SQL generation and error correction
 
-LLM_API_KEY is a convenience env var that auto-maps to the correct
-provider-specific env var based on the model prefix. For multi-provider
-setups, set provider-specific env vars directly instead.
+Each model's provider is extracted from its prefix (e.g. "anthropic"
+from "anthropic:claude-sonnet-4-6"). The provider-specific API key env
+var (e.g. ANTHROPIC_API_KEY) takes priority; LLM_API_KEY is used as a
+shared fallback for any provider that doesn't have its own key set.
 
 Supported provider prefixes: openai, anthropic, groq, mistral.
 Bedrock uses AWS creds (AWS_ACCESS_KEY_ID, etc.).
@@ -18,18 +19,15 @@ import os
 MODEL_LIGHT = os.getenv("MODEL_LIGHT", "anthropic:claude-haiku-4-5")
 MODEL_HEAVY = os.getenv("MODEL_HEAVY", "anthropic:claude-sonnet-4-6")
 
-_KEY_MAP = {
+KEY_MAP = {
     "openai": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
     "groq": "GROQ_API_KEY",
     "mistral": "MISTRAL_API_KEY",
 }
 
-_llm_key = os.getenv("LLM_API_KEY", "")
-if _llm_key:
-    _provider = MODEL_LIGHT.split(":")[0]
-    if _provider in _KEY_MAP:
-        os.environ.setdefault(_KEY_MAP[_provider], _llm_key)
-    _heavy_provider = MODEL_HEAVY.split(":")[0]
-    if _heavy_provider != _provider and _heavy_provider in _KEY_MAP:
-        os.environ.setdefault(_KEY_MAP[_heavy_provider], _llm_key)
+llm_fallback_key = os.getenv("LLM_API_KEY", "")
+for model in (MODEL_LIGHT, MODEL_HEAVY):
+    provider = model.split(":")[0]
+    if provider in KEY_MAP and llm_fallback_key:
+        os.environ.setdefault(KEY_MAP[provider], llm_fallback_key)

--- a/helm/geodini/templates/_helpers.tpl
+++ b/helm/geodini/templates/_helpers.tpl
@@ -62,6 +62,17 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Return the secret name to use for credentials.
+*/}}
+{{- define "geodini.secretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- .Values.secrets.existingSecret -}}
+{{- else -}}
+{{- include "geodini.fullname" . }}-geodini-secret
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "geodini.deployment.apiVersion" -}}

--- a/helm/geodini/templates/api-deployment.yaml
+++ b/helm/geodini/templates/api-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "geodini.serviceAccountName" . }}
       securityContext:
-        {}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
         - name: temp-dir
           emptyDir: {}
@@ -44,17 +44,17 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "geodini.fullname" . }}-geodini-secret
+                  name: {{ include "geodini.secretName" . }}
                   key: POSTGRES_USER
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "geodini.fullname" . }}-geodini-secret
+                  name: {{ include "geodini.secretName" . }}
                   key: POSTGRES_PASSWORD
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "geodini.fullname" . }}-geodini-secret
+                  name: {{ include "geodini.secretName" . }}
                   key: POSTGRES_DB
             - name: DATA_PATH
               value: /tmp/data
@@ -71,7 +71,7 @@ spec:
       containers:
         - name: api
           securityContext:
-            {}
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           command:
@@ -97,17 +97,17 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "geodini.fullname" . }}-geodini-secret
+                  name: {{ include "geodini.secretName" . }}
                   key: POSTGRES_USER
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "geodini.fullname" . }}-geodini-secret
+                  name: {{ include "geodini.secretName" . }}
                   key: POSTGRES_PASSWORD
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "geodini.fullname" . }}-geodini-secret
+                  name: {{ include "geodini.secretName" . }}
                   key: POSTGRES_DB
             - name: REDIS_HOST
               value: {{ .Values.api.env.REDIS_HOST | quote }}
@@ -122,11 +122,25 @@ spec:
                   name: {{ include "geodini.fullname" . }}-redis
                   key: redis-password
             {{- end }}
-            - name: OPENAI_API_KEY
+            - name: LLM_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "geodini.fullname" . }}-geodini-secret
-                  key: OPENAI_API_KEY
+                  name: {{ include "geodini.secretName" . }}
+                  key: LLM_API_KEY
+            - name: MODEL_LIGHT
+              value: {{ .Values.api.env.MODEL_LIGHT | quote }}
+            - name: MODEL_HEAVY
+              value: {{ .Values.api.env.MODEL_HEAVY | quote }}
+            - name: GEOMETRY_DECIMAL_PRECISION
+              value: {{ .Values.api.env.GEOMETRY_DECIMAL_PRECISION | quote }}
+            - name: GEOMETRY_DB_SIMPLIFY_TOLERANCE
+              value: {{ .Values.api.env.GEOMETRY_DB_SIMPLIFY_TOLERANCE | quote }}
+            - name: GEOMETRY_AGENT_SIMPLIFY_TOLERANCE
+              value: {{ .Values.api.env.GEOMETRY_AGENT_SIMPLIFY_TOLERANCE | quote }}
+            - name: GEOMETRY_MCP_SIMPLIFY_TOLERANCE
+              value: {{ .Values.api.env.GEOMETRY_MCP_SIMPLIFY_TOLERANCE | quote }}
+            - name: GEOMETRY_MAX_BYTES
+              value: {{ .Values.api.env.GEOMETRY_MAX_BYTES | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/helm/geodini/templates/frontend-deployment.yaml
+++ b/helm/geodini/templates/frontend-deployment.yaml
@@ -24,11 +24,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "geodini.serviceAccountName" . }}
       securityContext:
-        {}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: frontend
           securityContext:
-            {}
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
           command:

--- a/helm/geodini/templates/geodini-secret.yaml
+++ b/helm/geodini/templates/geodini-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.secrets.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,4 +11,5 @@ data:
   POSTGRES_USER: {{ .Values.secrets.POSTGRES_USER | b64enc | quote }}
   POSTGRES_PASSWORD: {{ .Values.secrets.POSTGRES_PASSWORD | b64enc | quote }}
   POSTGRES_DB: {{ .Values.secrets.POSTGRES_DB | b64enc | quote }}
-  OPENAI_API_KEY: {{ .Values.secrets.OPENAI_API_KEY | b64enc | quote }}
+  LLM_API_KEY: {{ .Values.secrets.LLM_API_KEY | b64enc | quote }}
+{{- end }}

--- a/helm/geodini/templates/postgres-deployment.yaml
+++ b/helm/geodini/templates/postgres-deployment.yaml
@@ -23,8 +23,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "geodini.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.postgres.podSecurityContext | nindent 8 }}
       containers:
         - name: postgres
+          securityContext:
+            {{- toYaml .Values.postgres.containerSecurityContext | nindent 12 }}
           image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
           imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
           ports:
@@ -35,17 +39,17 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "geodini.fullname" . }}-geodini-secret
+                  name: {{ include "geodini.secretName" . }}
                   key: POSTGRES_USER
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "geodini.fullname" . }}-geodini-secret
+                  name: {{ include "geodini.secretName" . }}
                   key: POSTGRES_PASSWORD
             - name: POSTGRES_DB  # Or POSTGRES_INITDB_ARGS for more complex init
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "geodini.fullname" . }}-geodini-secret
+                  name: {{ include "geodini.secretName" . }}
                   key: POSTGRES_DB
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata # Standard for postgres images
@@ -70,7 +74,7 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 6
           resources:
-            {} # Define resources
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data

--- a/helm/geodini/values.yaml
+++ b/helm/geodini/values.yaml
@@ -24,6 +24,15 @@ api:
     REDIS_PORT: "6379"
     REDIS_DB: "0"
     OVERTURE_DATA_VERSION: "2025-10-22.0" # Overture now only maintain data for 60 days so this will need to be updated https://docs.overturemaps.org/blog/2025/09/24/release-notes/
+    # Geometry configuration
+    GEOMETRY_DECIMAL_PRECISION: "6"         # Decimal places for coordinate rounding
+    GEOMETRY_DB_SIMPLIFY_TOLERANCE: "0.001" # ST_Simplify tolerance in degrees
+    GEOMETRY_AGENT_SIMPLIFY_TOLERANCE: "10000" # Shapely simplification tolerance in meters
+    GEOMETRY_MCP_SIMPLIFY_TOLERANCE: "1000" # MCP simplification tolerance in meters
+    GEOMETRY_MAX_BYTES: "0"                 # Max geometry size in bytes (0 = disabled)
+    # Model configuration — provider:model format (e.g., openai:gpt-4.1-mini, anthropic:claude-haiku-4-5, ollama:llama3)
+    MODEL_LIGHT: "anthropic:claude-haiku-4-5"   # Fast/cheap tasks: rephrase, routing, rerank
+    MODEL_HEAVY: "anthropic:claude-sonnet-4-6"  # SQL generation and error correction
     # POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB are taken from a secret
   initContainer:
     ingest:
@@ -68,6 +77,21 @@ postgres:
     type: ClusterIP # Internal service
     port: 5432
   # user, password, database configured in 'secrets'
+  # Postgres needs special security context: entrypoint runs as root, then drops to uid 999
+  podSecurityContext:
+    fsGroup: 999
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "2"
+      memory: "2Gi"
   persistence:
     enabled: true
     storageClassName: "" # Or your specific storage class
@@ -126,6 +150,21 @@ ingress:
   #   hosts:
   #     - api.geodini.local
 
+# Security contexts applied to all pods/containers by default
+podSecurityContext:
+  runAsNonRoot: true
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -137,7 +176,10 @@ serviceAccount:
 
 # Centralized secrets
 secrets:
+  # Set existingSecret to use a pre-created Kubernetes Secret (e.g., from Vault, Sealed Secrets)
+  # When set, the chart will not create its own Secret resource
+  existingSecret: ""
   POSTGRES_USER: "postgres"
-  POSTGRES_PASSWORD: "changeme" # IMPORTANT: Change for production
+  POSTGRES_PASSWORD: "" # REQUIRED: Set via --set or values file
   POSTGRES_DB: "postgres"
-  OPENAI_API_KEY: "YOUR_OPENAI_API_KEY_HERE" # IMPORTANT: Change for production
+  LLM_API_KEY: "" # REQUIRED: Set via --set or values file. Auto-maps to provider-specific env var (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "dotenv",
   "fastapi>=0.104.0",
   "numpy>=1.25.0",
+  "anthropic>=0.40.0",
   "openai>=1.0.0",
   "pandas>=2.0.0",
   "pluggy>=1.5.0",


### PR DESCRIPTION
Adds various configurable values to the chart:

- Agentic tasks either use a `MODEL_LIGHT` or `MODEL_HEAVY`, which can be configured. These now default to Haiku and Sonnet, as the original models used for these tasks are being deprecated.
- `OPENAI_API_KEY` -> `LLM_API_KEY`, this gets passed to `pydantic-ai` and is used according to the configured model.
- Added some different settings for geometry simplification. These are parameters already, but this allows us to set defaults for this behaviour. One of these settings is a "MAX_BYTES` setting, which will attempt to simplify a geometry until it fits in a certain number of bytes. This is useful if the geometry is being passed on to an API with content size limits. This type of simplification is disabled by default.
- Added a geometry lookup by ID - a user who already knows which geometry they want can retrieve it, possibly with different precision parameters.
- Added some defaults for pod/container security context.

Lightly tested, but will test it more thoroughly today. I wanted to get the PR up early for transparency.